### PR TITLE
Compile relocatable

### DIFF
--- a/HowToRelease.md
+++ b/HowToRelease.md
@@ -5,3 +5,6 @@
 1. Run the commented procedures of each of the release_*.sh files
 1. Run ./dist/sync.sh
 1. Change version and shasum in homembrew_crystal project.
+
+Note: If the initial build fails with git complaining there's no HEAD, remove the llvm_bin dependency
+from config/software/crystal.rb, run the build again and let fail and then undo the changes and try again.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,18 +5,23 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  [%w(debian chef/debian-7.4), %w(debian32 chef/debian-7.4-i386)].each do |name, box|
+  [%w(debian bento/debian-7.8), %w(debian32 bento/debian-7.8-i386)].each do |name, box|
     config.vm.define(name) do |c|
       c.vm.box = box
 
       c.vm.provision :shell, inline: %(
+        set -e
         echo "Installing rvm and ruby"
         export DEBIAN_FRONTEND=noninteractive
-        gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+        curl -#LO https://rvm.io/mpapis.asc
+        gpg --import mpapis.asc
         curl -sSL https://get.rvm.io | bash -s stable --ruby
+        source /usr/local/rvm/scripts/rvm
+        rvm use ruby --default
+        gem install bundler
 
         echo "Preparing omnibus"
-        apt-get -q -y  install git reprepro dpkg-sig
+        apt-get -q -y  install git reprepro dpkg-sig fakeroot
         mkdir -p /var/lib/bundle
         mount -o bind /var/lib/bundle /vagrant/.bundle
         cd /vagrant
@@ -25,11 +30,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  [%w(centos chef/centos-6.5), %w(centos32 chef/centos-6.5-i386)].each do |name, box|
+  [%w(centos bento/centos-6.7), %w(centos32 bento/centos-6.7-i386)].each do |name, box|
     config.vm.define(name) do |c|
       c.vm.box = box
 
       c.vm.provision :shell, inline: %(
+        set -e
         echo "%_signature gpg" > ~/.rpmmacros
         echo "%_gpg_name 7CC06B54" >> ~/.rpmmacros
 
@@ -39,8 +45,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         yum install -q -y devtoolset-1.1
 
         echo "Installing rvm and ruby"
-        gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+        curl -#LO https://rvm.io/mpapis.asc
+        gpg --import mpapis.asc
         curl -sSL https://get.rvm.io | bash -s stable --ruby
+        source /usr/local/rvm/scripts/rvm
+        rvm use ruby --default
+        gem install bundler
 
         echo "Preparing omnibus"
         yum install -q -y git xz rpm-build fakeroot createrepo

--- a/config/software/bdw-gc.rb
+++ b/config/software/bdw-gc.rb
@@ -9,6 +9,7 @@ dependency "libatomic_ops"
 relative_path "gc-#{version}"
 
 env = with_standard_compiler_flags(with_embedded_path)
+env["CFLAGS"] << " -fPIC"
 
 build do
   command "./configure" \

--- a/config/software/crystal.rb
+++ b/config/software/crystal.rb
@@ -15,6 +15,7 @@ dependency "libevent"
 env = with_standard_compiler_flags(with_embedded_path(
   "LIBRARY_PATH" => "#{install_dir}/embedded/lib"
 ))
+env["CFLAGS"] << " -fPIC"
 
 llvm_bin = Omnibus::Software.load(project, "llvm_bin")
 output_bin = "#{install_dir}/embedded/bin/crystal"

--- a/config/software/libatomic_ops.rb
+++ b/config/software/libatomic_ops.rb
@@ -7,6 +7,7 @@ source :url => "http://www.ivmaisoft.com/_bin/atomic_ops/libatomic_ops-7.4.2.tar
 relative_path 'libatomic_ops-7.4.2'
 
 env = with_standard_compiler_flags
+env["CFLAGS"] << " -fPIC"
 
 build do
   command "./configure" \

--- a/config/software/libevent.rb
+++ b/config/software/libevent.rb
@@ -6,6 +6,7 @@ source url: "https://github.com/libevent/libevent/archive/release-#{version}-sta
 
 relative_path "libevent-release-#{version}-stable"
 env = with_standard_compiler_flags(with_embedded_path)
+env["CFLAGS"] << " -fPIC"
 
 build do
   command "./autogen.sh"

--- a/config/software/libpcl.rb
+++ b/config/software/libpcl.rb
@@ -6,6 +6,7 @@ source url: "http://xmailserver.org/pcl-#{version}.tar.gz",
 
 relative_path "pcl-#{version}"
 env = with_standard_compiler_flags(with_embedded_path)
+env["CFLAGS"] << " -fPIC"
 
 build do
   command "./configure" \

--- a/config/software/libunwind.rb
+++ b/config/software/libunwind.rb
@@ -7,6 +7,7 @@ source url: "http://download.savannah.gnu.org/releases/libunwind/libunwind-#{ver
 relative_path "libunwind-#{version}"
 
 env = with_standard_compiler_flags(with_embedded_path)
+env["CFLAGS"] << " -fPIC"
 
 build do
   command "./configure" \

--- a/config/software/libuv.rb
+++ b/config/software/libuv.rb
@@ -6,6 +6,7 @@ source url: "https://github.com/libuv/libuv/archive/v#{version}.tar.gz",
 
 relative_path "libuv-#{version}"
 env = with_standard_compiler_flags(with_embedded_path)
+env["CFLAGS"] << " -fPIC"
 
 build do
   command "sh autogen.sh"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -66,7 +66,7 @@ build do
           }
         else
           {
-            "CFLAGS" => "-I#{install_dir}/embedded/include",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -fPIC",
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
           }
         end

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -24,6 +24,7 @@ relative_path "pcre-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  env["CFLAGS"] << " -fPIC"
 
   command "./configure" \
           " --prefix=#{install_dir}/embedded" \

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -34,6 +34,7 @@ build do
   # up the embedded libtool instead of the system libtool which the zlib
   # configure script cannot handle.
   env = with_standard_compiler_flags
+  env["CFLAGS"] << " -fPIC"
 
   # For some reason zlib needs this flag on solaris (cargocult warning?)
   env['CFLAGS'] << " -DNO_VIZ" if solaris2?


### PR DESCRIPTION
This allows to use the prebuilt packages in typical hardened environments where position independent code is required.

<del>Note that this will require a new release of the llvm project.</del>
